### PR TITLE
Update api calls to match Strapi v4

### DIFF
--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -8,9 +8,10 @@ import Layout from "../src/common/Layout";
 import { fetchAPI } from "../src/lib/api";
 
 const DynamicPage = ({ page }) => {
+  if (!page) return null;
   return (
     <Layout margin seo={page.seo}>
-      {page.block.map((block) => {
+      {page.block?.map((block) => {
         return {
           "sections.hero": (
             <Hero
@@ -86,7 +87,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const [page] = (await fetchAPI(`/pages?slug=${params.slug}`)) || {};
+  const [page] =
+    (await fetchAPI(`/pages?populate=*&slug=${params.slug}`)) || {};
 
   return {
     props: { key: page.id, page },

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -220,7 +220,7 @@ const Article = ({ article, context }) => {
 };
 
 export async function getStaticPaths() {
-  const articles = await fetchAPI("/articles");
+  const articles = await fetchAPI("/articles?populate=*");
 
   return {
     paths: articles.map((article) => ({
@@ -235,7 +235,9 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const [article] =
-    (await fetchAPI(`/articles?uid=${params.slug}&status=published`)) || {};
+    (await fetchAPI(
+      `/articles?populate=*&uid=${params.slug}&status=published`
+    )) || {};
 
   return {
     props: { article },

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -82,8 +82,8 @@ const News = ({ articles, categories }) => {
 };
 
 export async function getStaticProps() {
-  const categories = (await fetchAPI(`/categories`)) || {};
-  const articles = (await fetchAPI(`/articles`)) || {};
+  const categories = (await fetchAPI(`/categories?populate=*`)) || {};
+  const articles = (await fetchAPI(`/articles?populate=*`)) || {};
 
   return {
     props: { categories, articles },
@@ -91,5 +91,3 @@ export async function getStaticProps() {
 }
 
 export default News;
-
-// [{ category: "news", articles: [] }];

--- a/pages/club/[slug].tsx
+++ b/pages/club/[slug].tsx
@@ -10,15 +10,16 @@ import Link from "next/link";
 import { Block } from "src/types/pageTypes";
 
 const Dynamic = ({ page }) => {
+  if (!page) return null;
   return (
     <Layout
       seo={page.seo}
       header={page.title}
       cover={{
-        url: page.Seo.shareImage.url,
+        url: page.Seo?.shareImage?.url,
       }}
     >
-      {page.block.map((block: Block) => {
+      {page.block?.map((block: Block) => {
         const mobileDirection =
           block.imagePosition === "end" ? "column" : "column-reverse";
         const webDirection =
@@ -26,7 +27,7 @@ const Dynamic = ({ page }) => {
         return {
           "sections.hero": (
             <Hero
-              title={block?.title}
+              title={block.title}
               size={block.size || "xl"}
               subTitle={block.subTitle}
               // image={block.image}
@@ -91,7 +92,7 @@ const Dynamic = ({ page }) => {
 };
 
 export async function getStaticPaths() {
-  const pages = await fetchAPI("/pages");
+  const pages = await fetchAPI("/pages?populate=*");
 
   return {
     paths: pages.map((page) => ({
@@ -104,7 +105,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const [page] = (await fetchAPI(`/pages?slug=${params.slug}`)) || {};
+  const [page] =
+    (await fetchAPI(`/pages?populate=*&slug=${params.slug}`)) || {};
 
   return {
     props: { key: page.id, page },

--- a/pages/club/history/index.tsx
+++ b/pages/club/history/index.tsx
@@ -41,7 +41,7 @@ const ClubHistory = ({ history }) => {
 
 export async function getStaticProps() {
   // Run API calls in parallel
-  const [history] = await Promise.all([fetchAPI("/history")]);
+  const [history] = await Promise.all([fetchAPI("/history?populate=*")]);
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,7 +77,7 @@ const Home = (props) => {
   const { homepage, highlight, d1Upcoming } = props;
   const { getLongDate } = new Utils();
   return (
-    <Layout seo={homepage.seo} bg="brand.light" id="homepage">
+    <Layout seo={homepage?.seo} bg="brand.light" id="homepage">
       <PageContent>
         <Hero size="3xl" {...highlight} direct></Hero>
         <Section
@@ -101,20 +101,20 @@ const Home = (props) => {
             mx={8}
           >
             <NextMatchFont size="lg">Next Up: </NextMatchFont>
-            <MatchTeams match={d1Upcoming[0]} />
+            <MatchTeams match={d1Upcoming?.[0]} />
             <NextMatchText flex="2" className="next-match__text--date">
               <Flex gap="3" flex="2">
                 <NextMatchFont size="sm" color="white">
-                  {getLongDate(d1Upcoming[0].attributes.date)[0]}
+                  {getLongDate(d1Upcoming?.[0].date)[0]}
                 </NextMatchFont>
                 <NextMatchFont size="sm" color="white">
-                  {getLongDate(d1Upcoming[0].attributes.date)[1]}
+                  {getLongDate(d1Upcoming?.[0].date)[1]}
                 </NextMatchFont>
               </Flex>
             </NextMatchText>
             <NextMatchText flex="2">
               <NextMatchFont size="md" color="white">
-                {d1Upcoming[0].location}
+                {d1Upcoming?.[0].location}
               </NextMatchFont>
             </NextMatchText>
             <Box flex="1">
@@ -150,13 +150,17 @@ export async function getStaticProps() {
     // d3Upcoming,
     homeCta,
   ] = await Promise.all([
-    fetchAPI("/articles?status=published&_sort=publishedAt:asc&_limit=3"),
-    fetchAPI("/homepage"),
+    fetchAPI(
+      "/articles?populate=*&status=published&_sort=publishedAt:asc&_limit=3"
+    ),
+    fetchAPI("/homepage?populate=*"),
     // fetchAPI("/games?division=d1&finished=true&_sort=date:asc&_limit=3"),
-    fetchAPI("/games?division=d1&finished=false&_sort=date:asc&_limit=1"),
+    fetchAPI(
+      "/games?populate=*&division=d1&finished=false&_sort=date:asc&_limit=1"
+    ),
     // fetchAPI("/games?division=d3&finished=true&_sort=date:asc&_limit=3"),
     // fetchAPI("/games?division=d3&finished=false&_sort=date:asc&_limit=3"),
-    fetchAPI("/home-cta"),
+    fetchAPI("/home-cta?populate=*"),
   ]);
   return {
     props: {

--- a/pages/schedule/components/Results.jsx
+++ b/pages/schedule/components/Results.jsx
@@ -43,13 +43,13 @@ const Results = ({ results }) => {
       {results?.map((game) => {
         const gameInfoProps = {
           homeTeam: {
-            name: game.home.name,
-            logo: game.home.logo,
+            name: game.home?.name,
+            logo: game.home?.logo,
             score: game.home_score,
           },
           awayTeam: {
-            name: game.away.name,
-            logo: game.away.logo,
+            name: game.away?.name,
+            logo: game.away?.logo,
             score: game.away_score,
           },
           location: game.location,
@@ -87,9 +87,9 @@ const Results = ({ results }) => {
                     textTransform="uppercase"
                     fontFamily="body"
                   >
-                    {isHome(game?.home?.name)
-                      ? `${game?.home?.name} - ${game?.away?.name}`
-                      : `${game?.away?.name} @ ${game?.home?.name}`}
+                    {isHome(game.home?.name)
+                      ? `${game.home?.name} - ${game.away?.name}`
+                      : `${game.away?.name} @ ${game.home?.name}`}
                   </Text>
                 </Box>
                 <AccordionIcon />

--- a/pages/schedule/components/Schedule.jsx
+++ b/pages/schedule/components/Schedule.jsx
@@ -36,7 +36,6 @@ const Schedule = ({ upcoming }) => {
   return (
     <Accordion allowMultiple defaultIndex={[0]}>
       {upcoming?.map((game) => {
-        game = game.attributes;
         const gameInfoProps = {
           homeTeam: {
             name: game?.home?.name,

--- a/pages/schedule/index.js
+++ b/pages/schedule/index.js
@@ -6,7 +6,7 @@ import { fetchAPI } from "../../src/lib/api";
 import ScheduleTabs from "./components/ScheduleTabs";
 
 const Schedule = ({ games }) => {
-  const { d1, d3 } = groupBy(games, "attributes.division");
+  const { d1, d3 } = groupBy(games, "division");
   const seo = {
     metaTitle: "Schedule",
   };
@@ -49,7 +49,7 @@ const Schedule = ({ games }) => {
 
 export async function getStaticProps() {
   // Run API calls in parallel
-  const [games] = await Promise.all([fetchAPI("/games")]);
+  const [games] = await Promise.all([fetchAPI("/games?populate=*")]);
 
   return {
     props: {

--- a/pages/team/[division]/[slug].js
+++ b/pages/team/[division]/[slug].js
@@ -65,7 +65,7 @@ const Player = ({ player }) => {
 };
 
 export async function getStaticPaths() {
-  const players = await fetchAPI("/players");
+  const players = await fetchAPI("/players?populate=*");
   return {
     paths: players.map((player) => ({
       params: {
@@ -79,7 +79,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const [player] = (await fetchAPI(`/players?slug=${params.slug}`)) || {};
+  const [player] =
+    (await fetchAPI(`/players?populate=*&slug=${params.slug}`)) || {};
   return {
     props: { player },
   };

--- a/pages/team/[division]/index.js
+++ b/pages/team/[division]/index.js
@@ -43,8 +43,8 @@ export async function getStaticProps({ params, ...ctx }) {
 
   const list = await fetchAPI(
     ["d1", "d3"].includes(division)
-      ? `/players?division=${division.toUpperCase()}`
-      : `/coaches`
+      ? `/players?populate=*&division=${division.toUpperCase()}`
+      : `/coaches?populate=*`
   );
   return {
     props: { list, division },

--- a/src/components/Games/MatchTeams.tsx
+++ b/src/components/Games/MatchTeams.tsx
@@ -51,7 +51,7 @@ const MatchTeams = ({ match }: { match: MatchType }) => {
       <TeamLogoContainer>
         <Image
           alt={home?.name}
-          src={home?.logo.formats.small.url}
+          src={home?.logo?.formats.small.url}
           objectFit="contain"
           fill
         />
@@ -60,7 +60,7 @@ const MatchTeams = ({ match }: { match: MatchType }) => {
       <TeamLogoContainer>
         <Image
           alt={away?.name}
-          src={away?.logo.formats.small.url}
+          src={away?.logo?.formats.small.url}
           objectFit="contain"
           fill
         />

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,6 @@
 export function getStrapiURL(path = "", useLocal) {
   return useLocal
-    ? `http://localhost:1339${path}`
+    ? `http://localhost:1337/api${path}`
     : `${process.env.strapi}${path}`;
 }
 


### PR DESCRIPTION
- Added `populate=*` to api calls https://docs.strapi.io/dev-docs/api/rest/populate-select
- Revert data that uses `attributes`
- Optional chaining on values that can be empty
- Need to change some api calls to use the updated parameters from Strapi v4